### PR TITLE
Stairs, Mining, Animal Crate Fixes

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1491,44 +1491,6 @@
 		/obj/structure/largecrate/animal/hakhma = 0.5
 	)
 
-//obj/random/random_flag
-	name = "random flag"
-	desc = "Contains a random boxed flag or banner."
-	icon = 'icons/obj/decals.dmi'
-	icon_state = "flag_boxed"
-	spawnlist = list(
-		//obj/item/flag/biesel,
-		//obj/item/flag/biesel/l,
-		//obj/item/flag/dominia,
-		//obj/item/flag/dominia/l,
-		//obj/item/flag/dpra,
-		//obj/item/flag/dpra/l,
-		//obj/item/flag/elyra,
-		//obj/item/flag/elyra/l,
-		//obj/item/flag/eridani,
-		//obj/item/flag/eridani/l,
-		//obj/item/flag/hegemony,
-		//obj/item/flag/hegemony/l,
-		//obj/item/flag/heph,
-		//obj/item/flag/heph/l,
-		//obj/item/flag/jargon,
-		//obj/item/flag/jargon/l,
-		//obj/item/flag/nanotrasen,
-		//obj/item/flag/nanotrasen/l,
-		//obj/item/flag/nka,
-		//obj/item/flag/nka/l,
-		//obj/item/flag/pra,
-		//obj/item/flag/pra/l,
-		//obj/item/flag/sol,
-		//obj/item/flag/sol/l,
-		//obj/item/flag/vaurca,
-		//obj/item/flag/vaurca/l,
-		//obj/item/flag/zenghu,
-		//obj/item/flag/zenghu/l,
-		//obj/item/flag/coalition,
-		//obj/item/flag/coalition/l
-	)
-
 /obj/random/gift
 	name = "random gift"
 	desc = "Contains a randomly sized gift."

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -38,7 +38,7 @@
 		var/area/A = get_area(src)
 		var/best_distance = INFINITY
 		for(var/obj/machinery/mineral/stacking_machine/checked_machine in SSmachinery.all_machines)
-			if(A == get_area(checked_machine) && get_dist_euclidian(checked_machine,src) < best_distance)
+			if(A == get_area(checked_machine) && !checked_machine.console && get_dist_euclidian(checked_machine,src) < best_distance)
 				machine = checked_machine
 				best_distance = get_dist_euclidian(checked_machine,src)
 		if(machine)

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -2698,7 +2698,7 @@
 	name = "legate's closet";
 	req_access = list(108,111)
 	},
-/obj/structure/sign/flag/biesel{
+/obj/structure/sign/flag/nanotrasen{
 	pixel_y = 32
 	},
 /obj/item/shield/energy/legion,
@@ -2713,10 +2713,10 @@
 /obj/item/storage/backpack/satchel,
 /obj/item/clothing/shoes/jackboots/toeless,
 /obj/item/clothing/glasses/sunglasses/aviator,
-/obj/item/flag/biesel/l{
+/obj/item/flag/nanotrasen/l{
 	pixel_y = 8
 	},
-/obj/item/flag/biesel,
+/obj/item/flag/nanotrasen,
 /turf/unsimulated/floor{
 	icon_state = "wood_light"
 	},
@@ -3835,9 +3835,9 @@
 /area/centcom/holding)
 "avW" = (
 /turf/unsimulated/floor{
+	dir = 4;
 	icon_state = "ramptop";
-	name = "staircase";
-	dir = 4
+	name = "staircase"
 	},
 /area/centcom/bar)
 "awh" = (
@@ -6484,7 +6484,7 @@
 	},
 /area/centcom/holding)
 "bcv" = (
-/obj/structure/sign/flag/biesel{
+/obj/structure/sign/flag/nanotrasen{
 	pixel_y = 32
 	},
 /obj/machinery/button/remote/blast_door{
@@ -7660,7 +7660,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
 	},
-/obj/item/storage/box/tcfl_pamphlet,
+/obj/item/storage/box/donkpockets,
 /turf/unsimulated/floor{
 	icon_state = "carpet5-1"
 	},
@@ -8032,9 +8032,9 @@
 	req_access = list(109)
 	},
 /obj/machinery/door/window{
+	dir = 1;
 	name = "South Checkpoint";
-	req_access = list(109);
-	dir = 1
+	req_access = list(109)
 	},
 /turf/unsimulated/floor/plating,
 /area/centcom/holding)
@@ -8647,9 +8647,9 @@
 "cEa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window{
+	dir = 1;
 	name = "North Checkpoint";
-	req_access = list(109);
-	dir = 1
+	req_access = list(109)
 	},
 /obj/machinery/door/window{
 	name = "North Checkpoint";
@@ -10530,7 +10530,7 @@
 /turf/space/dynamic,
 /area/shuttle/skipjack)
 "dVZ" = (
-/obj/structure/sign/flag/biesel{
+/obj/structure/sign/flag/nanotrasen{
 	pixel_y = 30
 	},
 /turf/unsimulated/floor{
@@ -15208,16 +15208,16 @@
 	dir = 5
 	},
 /obj/machinery/button/remote/blast_door{
-	pixel_x = 30;
-	pixel_y = -4;
+	id = "south1";
 	name = "Enter";
-	id = "south1"
+	pixel_x = 30;
+	pixel_y = -4
 	},
 /obj/machinery/button/remote/blast_door{
-	pixel_x = 30;
-	pixel_y = 7;
+	id = "south2";
 	name = "Exit";
-	id = "south2"
+	pixel_x = 30;
+	pixel_y = 7
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -22670,16 +22670,16 @@
 	dir = 10
 	},
 /obj/machinery/button/remote/blast_door{
-	pixel_x = -30;
-	pixel_y = -4;
+	id = "north1";
 	name = "Enter";
-	id = "north1"
+	pixel_x = -30;
+	pixel_y = -4
 	},
 /obj/machinery/button/remote/blast_door{
-	pixel_x = -30;
-	pixel_y = 7;
+	id = "north2";
 	name = "Exit";
-	id = "north2"
+	pixel_x = -30;
+	pixel_y = 7
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -25310,7 +25310,7 @@
 /obj/effect/floor_decal/corner/lime/diagonal{
 	dir = 8
 	},
-/obj/structure/sign/flag/biesel/left{
+/obj/structure/sign/flag/nanotrasen/left{
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
@@ -25439,7 +25439,7 @@
 /obj/effect/floor_decal/corner/lime/diagonal{
 	dir = 8
 	},
-/obj/structure/sign/flag/biesel/right{
+/obj/structure/sign/flag/nanotrasen/right{
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
@@ -26313,9 +26313,9 @@
 	icon_state = "mcorneroverlay1"
 	},
 /turf/unsimulated/floor{
+	dir = 4;
 	icon_state = "ramptop";
-	name = "staircase";
-	dir = 4
+	name = "staircase"
 	},
 /area/centcom/bar)
 "pxn" = (
@@ -26452,9 +26452,9 @@
 	icon_state = "mcorneroverlay1"
 	},
 /turf/unsimulated/floor{
+	dir = 4;
 	icon_state = "ramptop";
-	name = "staircase";
-	dir = 4
+	name = "staircase"
 	},
 /area/centcom/bar)
 "pCm" = (
@@ -26904,7 +26904,7 @@
 /area/shuttle/specops)
 "pMW" = (
 /obj/vehicle/bike/speeder,
-/obj/structure/sign/flag/biesel/left{
+/obj/structure/sign/flag/nanotrasen/left{
 	pixel_y = 32
 	},
 /turf/unsimulated/floor,
@@ -26922,7 +26922,7 @@
 	dir = 4
 	},
 /obj/vehicle/bike/speeder,
-/obj/structure/sign/flag/biesel/right{
+/obj/structure/sign/flag/nanotrasen/right{
 	pixel_y = 32
 	},
 /turf/unsimulated/floor,
@@ -29293,22 +29293,22 @@
 	locked = 0;
 	opened = 1
 	},
-/obj/item/flag/biesel/l{
+/obj/item/flag/nanotrasen/l{
 	pixel_y = 8
 	},
-/obj/item/flag/biesel/l{
+/obj/item/flag/nanotrasen/l{
 	pixel_y = 8
 	},
-/obj/item/flag/biesel{
+/obj/item/flag/nanotrasen{
 	pixel_y = 8
 	},
-/obj/item/flag/biesel{
+/obj/item/flag/nanotrasen{
 	pixel_y = 8
 	},
-/obj/item/flag/biesel{
+/obj/item/flag/nanotrasen{
 	pixel_y = 8
 	},
-/obj/item/storage/box/tcfl_pamphlet,
+/obj/item/storage/box/donkpockets,
 /obj/item/material/twohanded/pike/flag,
 /turf/unsimulated/floor,
 /area/centcom/legion/hangar5)
@@ -30745,8 +30745,8 @@
 /area/centcom/legion)
 "teA" = (
 /mob/living/silicon/decoy{
-	name = "Draconis";
-	icon_state = "ai-matrix"
+	icon_state = "ai-matrix";
+	name = "Draconis"
 	},
 /turf/unsimulated/floor{
 	icon_state = "virtual_reality2"
@@ -32141,7 +32141,7 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
-/obj/structure/sign/flag/biesel/left{
+/obj/structure/sign/flag/nanotrasen/left{
 	pixel_y = 32
 	},
 /obj/structure/table/standard,
@@ -32262,7 +32262,7 @@
 	pixel_x = 5;
 	pixel_y = 12
 	},
-/obj/structure/sign/flag/biesel/right{
+/obj/structure/sign/flag/nanotrasen/right{
 	pixel_y = 32
 	},
 /obj/structure/table/standard,
@@ -32795,7 +32795,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/sign/flag/biesel{
+/obj/structure/sign/flag/nanotrasen{
 	pixel_x = 5;
 	pixel_y = 32
 	},
@@ -32973,7 +32973,7 @@
 /turf/unsimulated/floor,
 /area/centcom/legion)
 "uSG" = (
-/obj/structure/sign/flag/biesel{
+/obj/structure/sign/flag/nanotrasen{
 	pixel_x = -5;
 	pixel_y = 32
 	},
@@ -33284,9 +33284,7 @@
 /turf/simulated/floor/shuttle/black,
 /area/shuttle/mercenary)
 "vdh" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 2
-	},
+/obj/effect/floor_decal/spline/fancy,
 /turf/unsimulated/floor/plating{
 	icon_state = "freezer"
 	},
@@ -33538,9 +33536,7 @@
 /area/antag/raider)
 "vpg" = (
 /obj/structure/table/stone/marble,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 2
-	},
+/obj/effect/floor_decal/spline/fancy,
 /turf/unsimulated/floor/plating{
 	icon_state = "freezer"
 	},
@@ -33910,7 +33906,7 @@
 /area/centcom/holding)
 "vKl" = (
 /obj/structure/undies_wardrobe,
-/obj/structure/sign/flag/biesel{
+/obj/structure/sign/flag/nanotrasen{
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
@@ -35037,16 +35033,16 @@
 	locked = 0;
 	opened = 1
 	},
-/obj/item/flag/biesel{
+/obj/item/flag/nanotrasen{
 	pixel_y = 8
 	},
-/obj/item/flag/biesel/l{
+/obj/item/flag/nanotrasen/l{
 	pixel_y = 8
 	},
-/obj/item/flag/biesel/l{
+/obj/item/flag/nanotrasen/l{
 	pixel_y = 8
 	},
-/obj/item/storage/box/tcfl_pamphlet,
+/obj/item/storage/box/donkpockets,
 /obj/item/material/twohanded/pike/flag,
 /turf/unsimulated/floor{
 	icon_state = "wood_light"
@@ -35793,7 +35789,7 @@
 	pixel_y = -4
 	},
 /obj/structure/table/standard,
-/obj/structure/sign/flag/biesel{
+/obj/structure/sign/flag/nanotrasen{
 	pixel_x = -32;
 	pixel_y = 32
 	},

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -30188,13 +30188,13 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
 "bcb" = (
-/obj/effect/shuttle_landmark/merc/start,
+/obj/effect/shuttle_landmark/merc/surface,
 /turf/simulated/floor/snow{
 	temperature = 234.15
 	},
 /area/mine/explored)
 "bcc" = (
-/obj/effect/shuttle_landmark/emergency/start,
+/obj/effect/shuttle_landmark/emergency/dock,
 /turf/simulated/floor/snow{
 	temperature = 234.15
 	},
@@ -44737,7 +44737,7 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
 "bCA" = (
-/obj/effect/shuttle_landmark/ert/start,
+/obj/effect/shuttle_landmark/ert/dock,
 /turf/simulated/floor/snow{
 	temperature = 234.15
 	},
@@ -52781,7 +52781,6 @@
 /area/rnd/research)
 "bQK" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -53078,28 +53077,6 @@
 	icon_state = "white"
 	},
 /area/rnd/research)
-"bRk" = (
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Psychiatry Isolation Room";
-	dir = 4;
-	network = list("Medical","Isolation Room")
-	},
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_y = 30
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"bRl" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "bRm" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -53244,19 +53221,6 @@
 	icon_state = "plating"
 	},
 /area/solar/starboard)
-"bRy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/medical/medbay2)
 "bRz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53564,33 +53528,22 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "bSd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/floor_decal/corner/mauve,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/vending/medical{
+	density = 0;
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
@@ -53630,38 +53583,18 @@
 /turf/simulated/wall,
 /area/chapel/main)
 "bSj" = (
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/corner/mauve{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"bSk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"bSl" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"bSm" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
+/area/medical/medbay2)
+"bSm" = (
+/turf/simulated/floor/ice,
 /area/medical/medbay2)
 "bSn" = (
 /obj/machinery/door/airlock/maintenance,
@@ -53871,25 +53804,8 @@
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/chemistry)
 "bSJ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/stairs/north,
+/turf/simulated/floor/tiled/ramp,
 /area/medical/medbay2)
 "bSK" = (
 /obj/machinery/mineral/stacking_unit_console{
@@ -53979,57 +53895,40 @@
 /turf/simulated/wall,
 /area/crew_quarters/locker/locker_toilet)
 "bSV" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/grille,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/plating,
 /area/medical/medbay2)
 "bSW" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Psychiatry Isolation Room";
+	dir = 4;
+	network = list("Medical","Isolation Room")
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "bSX" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "bSY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	layer = 5;
-	name = "adjusted window"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "bSZ" = (
 /obj/structure/table/reinforced,
@@ -54526,19 +54425,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_three)
 "bTM" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+/area/mine/explored)
 "bTN" = (
 /turf/simulated/floor/wood,
 /area/chapel/office)
@@ -54552,6 +54443,10 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "bTP" = (
@@ -55307,21 +55202,17 @@
 /turf/simulated/floor/plating,
 /area/medical/pharmacy)
 "bVg" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+/area/mine/explored)
 "bVh" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/brown{
@@ -55870,8 +55761,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_three)
 "bWi" = (
-/obj/structure/stairs/south,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/ramp/bottom,
 /area/medical/medbay2)
 "bWj" = (
 /obj/structure/window/reinforced{
@@ -55880,18 +55770,18 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,
+/obj/machinery/atmospherics/pipe/zpipe/up/supply,
+/obj/structure/cable/green{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	dir = 1
-	},
-/obj/structure/cable/green,
-/obj/structure/window/reinforced,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "12-0"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated{
 	icon_state = "steel_dirty"
@@ -56256,21 +56146,17 @@
 /turf/simulated/floor/plating,
 /area/medical/pharmacy)
 "bWM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 6
-	},
-/obj/machinery/vending/medical{
-	density = 0;
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC";
 	pixel_x = 32
 	},
+/obj/effect/floor_decal/corner/mauve{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+/area/mine/explored)
 "bWN" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled,
@@ -56877,7 +56763,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
 	},
@@ -57173,17 +57058,11 @@
 /turf/simulated/floor/ice,
 /area/mine/explored)
 "bYA" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "bYB" = (
 /obj/structure/closet/crate,
@@ -57580,21 +57459,40 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "bZk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "bZl" = (
 /obj/structure/window/reinforced{
@@ -57748,7 +57646,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
 "bZD" = (
-/obj/machinery/mineral/input,
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 4
 	},
@@ -57854,7 +57751,9 @@
 	},
 /area/rnd/mixing)
 "bZP" = (
-/obj/machinery/mineral/processing_unit,
+/obj/machinery/mineral/processing_unit{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
 "bZQ" = (
@@ -57896,7 +57795,9 @@
 	dir = 4;
 	id = "ml"
 	},
-/obj/machinery/mineral/stacking_machine,
+/obj/machinery/mineral/stacking_machine{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
 "bZU" = (
@@ -57922,7 +57823,9 @@
 	},
 /area/rnd/research)
 "bZX" = (
-/obj/machinery/mineral/processing_unit,
+/obj/machinery/mineral/processing_unit{
+	dir = 4
+	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
@@ -58610,7 +58513,9 @@
 	dir = 4;
 	id = "ml"
 	},
-/obj/machinery/mineral/stacking_machine,
+/obj/machinery/mineral/stacking_machine{
+	dir = 4
+	},
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "ml"
@@ -82452,12 +82357,53 @@
 	icon_state = "darkmarble"
 	},
 /area/engineering/workshop)
+"ifY" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine/explored)
 "iUR" = (
 /turf/simulated/wall,
 /area/hallway/primary/aft)
+"jcu" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/medical/medbay2)
 "jDA" = (
 /turf/simulated/wall,
 /area/engineering/atmos)
+"kjL" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/mine/explored)
 "kHW" = (
 /turf/simulated/wall,
 /area/maintenance/substation/engineering)
@@ -82510,6 +82456,23 @@
 "qba" = (
 /turf/simulated/wall,
 /area/maintenance/atmos_control)
+"rwV" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine/explored)
 "tKG" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -121967,9 +121930,9 @@ bNl
 bOK
 bQy
 bSd
-bTG
-bVg
-bWM
+bOK
+bOK
+bOK
 bXU
 bZj
 bTO
@@ -122223,14 +122186,14 @@ bLm
 bkr
 bQK
 bSj
-bSJ
+bkr
 bQK
-bkr
-bkr
+bSV
+cbD
 bYA
 bZk
-bZk
-bZk
+bkr
+jcu
 cbD
 bkr
 cgY
@@ -122478,15 +122441,15 @@ bHA
 bJk
 bLn
 bkr
-bRk
-cmo
-bSV
-bJk
-bWi
+bSm
+bSm
 bkr
-baf
-baf
-baf
+bSJ
+bWi
+bSW
+bTM
+kjL
+aaI
 baf
 baf
 bkr
@@ -122735,15 +122698,15 @@ bHB
 bJl
 bLo
 bPa
-bJk
-bSk
-bSW
-bTM
-bWj
+bSm
+bSm
 bkr
-baf
-baf
-baf
+bkr
+bWj
+bSX
+bVg
+rwV
+aaI
 baf
 baf
 bkr
@@ -122992,15 +122955,15 @@ bHC
 bJm
 bLn
 bkr
-bRl
-bSl
-bSX
-bJk
-bWi
+bSm
+bSm
 bkr
-baf
-baf
-baf
+bSJ
+bWi
+bSY
+bWM
+ifY
+aaI
 baf
 baf
 bkr
@@ -123249,15 +123212,15 @@ bHA
 bJm
 bLt
 bkr
-bRy
 bSm
-bSY
+bSm
 bkr
 bkr
 bkr
-aBt
-baf
-baf
+bkr
+aaI
+aaI
+aaI
 baf
 baf
 bkr

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -920,10 +920,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/upperlevel)
-"bM" = (
-/obj/structure/stairs/south,
-/turf/simulated/open/airless,
-/area/medical/psych)
 "bN" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -944,7 +940,7 @@
 	d2 = 2;
 	icon_state = "12-0"
 	},
-/turf/simulated/open/airless,
+/turf/simulated/open,
 /area/medical/psych)
 "bO" = (
 /obj/machinery/alarm{
@@ -1569,14 +1565,14 @@
 /turf/simulated/floor/plating,
 /area/medical/psych)
 "hD" = (
-/turf/simulated/open/airless,
+/turf/simulated/open,
 /area/medical/psych)
 "MZ" = (
-/obj/effect/shuttle_landmark/burglar/start,
+/obj/effect/shuttle_landmark/burglar/surface,
 /turf/simulated/floor/airless/ceiling,
 /area/space)
 "YN" = (
-/obj/effect/shuttle_landmark/skipjack/start,
+/obj/effect/shuttle_landmark/skipjack/interstitial,
 /turf/simulated/floor/airless/ceiling,
 /area/space)
 
@@ -41537,7 +41533,7 @@ aC
 aW
 bk
 hD
-bM
+hD
 au
 cb
 cm
@@ -42051,7 +42047,7 @@ aE
 aW
 bm
 hD
-bM
+hD
 au
 cd
 co

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -631,10 +631,16 @@
 	},
 /area/tcommsat/entrance)
 "bz" = (
-/obj/machinery/power/smes/buildable,
 /obj/structure/cable/blue{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/power/smes/buildable{
+	charge = 5e+006;
+	input_attempt = 1;
+	input_level = 200000;
+	output_attempt = 1;
+	output_level = 200000
 	},
 /turf/simulated/floor/fixed,
 /area/tcommsat/entrance)
@@ -860,10 +866,10 @@
 /area/tcommsat/entrance)
 "tI" = (
 /obj/machinery/airlock_sensor/airlock_interior{
-	pixel_y = 30;
 	frequency = 1212;
 	id_tag = "tcommint";
-	master_tag = "tcommmaster"
+	master_tag = "tcommmaster";
+	pixel_y = 30
 	},
 /obj/machinery/access_button/airlock_interior{
 	frequency = 1212;
@@ -979,9 +985,9 @@
 /area/tcommsat/computer)
 "LP" = (
 /obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
-	pixel_y = 30;
 	frequency = 1212;
 	id_tag = "tcommmaster";
+	pixel_y = 30;
 	tag_airpump = "tcommpump";
 	tag_chamber_sensor = "tcommsensor1";
 	tag_exterior_door = "tcommextdoor";
@@ -991,9 +997,9 @@
 	tag_secure = 1
 	},
 /obj/machinery/airlock_sensor{
-	pixel_y = 20;
 	frequency = 1212;
-	id_tag = "tcommsensor1"
+	id_tag = "tcommsensor1";
+	pixel_y = 20
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -1075,10 +1081,10 @@
 /area/tcommsat/entrance)
 "Ub" = (
 /obj/machinery/airlock_sensor{
-	pixel_y = 30;
 	frequency = 1212;
 	id_tag = "tcommext";
-	master_tag = "tcommmaster"
+	master_tag = "tcommmaster";
+	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4


### PR DESCRIPTION
# Make sure to delete this placeholder text otherwise it'll look very goofy in your PR.

* Remapped the medical stairway to not lead you to a sheer wall.
* Fixed the mining machines outputting in the wrong direction, and the stacker top stealing the console from the stacker bottom.
* Replaced the Biesel flags on the Centcomm level with NT ones to stop the errors.
* Replaced some shuttle waypoints to their "correct" variants, there were multiple "start" waypoints.
* Copied the Aurora Telecomms SMES to provide TComms with enough power for the first bit of the round.

Old:
![image](https://user-images.githubusercontent.com/22774890/156618524-20298d5f-5951-4c4f-9748-a345af59d1ba.png)

New:
![image](https://user-images.githubusercontent.com/22774890/156618503-088bde3a-45e8-45be-8790-8b89bb9da234.png)
