### PR TITLE
Fixes Loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -18,6 +18,9 @@ var/list/gear_datums = list()
 		var/use_name = initial(G.display_name)
 		var/use_category = initial(G.sort_category)
 
+		if(!use_name)
+			crash_with(G.type)
+
 		if(!loadout_categories[use_category])
 			loadout_categories[use_category] = new /datum/loadout_category(use_category)
 		var/datum/loadout_category/LC = loadout_categories[use_category]

--- a/code/modules/client/preference_setup/loadout/loadout_religion.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_religion.dm
@@ -1,8 +1,4 @@
-/datum/gear/religion/rosary
-	display_name = "rosary"
-	path = /obj/item/clothing/accessory/rosary
-
-/datum/gear/religion/rosary
+/datum/gear/religion
 	display_name = "rosary"
 	path = /obj/item/clothing/accessory/rosary
 


### PR DESCRIPTION
# Make sure to delete this placeholder text otherwise it'll look very goofy in your PR.

* Makes the base level `/datum/gear/religion` path into an actual item to prevent a null name from entering the list.
* Added a crash_with that will deploy runtimes to make future cases easier to catch.