### PR TITLE
Makes KAs not useless, gives specific hardsuits backpacks

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -206,7 +206,7 @@
 	icon = 'icons/clothing/rig/offworlder.dmi'
 	icon_state = "offworlder_rig"
 	icon_supported_species_tags = null
-	allowed = list(/obj/item/tank, /obj/item/device/flashlight)
+	allowed = list(/obj/item/tank, /obj/item/device/flashlight,/obj/item/storage/backpack)
 	armor = list(
 		bio = ARMOR_BIO_MINOR,
 		rad = ARMOR_RAD_MINOR

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -25,7 +25,7 @@
 	emp_protection = 30
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/merc
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword,/obj/item/handcuffs,/obj/item/material/twohanded/fireaxe)
+	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword,/obj/item/handcuffs,/obj/item/material/twohanded/fireaxe,/obj/item/storage/backpack)
 
 	req_access = list(access_syndicate)
 

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -90,7 +90,7 @@
 	helm_type = /obj/item/clothing/head/helmet/space/rig/industrial
 	chest_type = /obj/item/clothing/suit/space/rig/industrial
 
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/bag/ore,/obj/item/pickaxe, /obj/item/gun/custom_ka,/obj/item/material/twohanded/fireaxe,/obj/item/gun/energy/vaurca/thermaldrill,/obj/item/storage/backpack/cell,/obj/item/rfd/mining)
+	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/bag/ore,/obj/item/pickaxe, /obj/item/gun/custom_ka,/obj/item/material/twohanded/fireaxe,/obj/item/gun/energy/vaurca/thermaldrill,/obj/item/storage/backpack/cell,/obj/item/rfd/mining,/obj/item/storage/backpack)
 
 	req_access = list()
 	req_one_access = list()
@@ -137,7 +137,7 @@
 	helm_type = /obj/item/clothing/head/helmet/space/rig/eva
 	glove_type = /obj/item/clothing/gloves/rig/eva
 
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/bag/inflatable,/obj/item/device/t_scanner,/obj/item/rfd/construction,/obj/item/material/twohanded/fireaxe,/obj/item/storage/backpack/cell)
+	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/bag/inflatable,/obj/item/device/t_scanner,/obj/item/rfd/construction,/obj/item/material/twohanded/fireaxe,/obj/item/storage/backpack)
 
 	req_access = list()
 	req_one_access = list()
@@ -190,7 +190,7 @@
 	helm_type = /obj/item/clothing/head/helmet/space/rig/ce
 	glove_type = /obj/item/clothing/gloves/rig/ce
 
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/bag/ore,/obj/item/device/t_scanner,/obj/item/pickaxe,/obj/item/material/twohanded/fireaxe,/obj/item/rfd/construction,/obj/item/storage/backpack/cell,/obj/item/storage/toolbox,/obj/item/storage/bag/inflatable)
+	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/bag/ore,/obj/item/device/t_scanner,/obj/item/pickaxe,/obj/item/material/twohanded/fireaxe,/obj/item/rfd/construction,/obj/item/storage/backpack/cell,/obj/item/storage/toolbox,/obj/item/storage/backpack)
 
 	req_access = list()
 	req_one_access = list()

--- a/code/modules/custom_ka/projectiles.dm
+++ b/code/modules/custom_ka/projectiles.dm
@@ -27,7 +27,7 @@
 
 /obj/item/projectile/kinetic/proc/do_damage(var/turf/T, var/living_damage = 1, var/mineral_damage = 1)
 	var/datum/gas_mixture/environment = T.return_air()
-	living_damage *= max(1 - (environment.return_pressure() / 50) * 0.75, 0)
+	living_damage *= max(1 - (environment.return_pressure() / 200) * 0.75, 0)
 	new /obj/effect/overlay/temp/kinetic_blast(T)
 	for(var/mob/living/L in T)
 		L.take_overall_damage(min(living_damage, 50))

--- a/code/modules/custom_ka/projectiles.dm
+++ b/code/modules/custom_ka/projectiles.dm
@@ -27,7 +27,7 @@
 
 /obj/item/projectile/kinetic/proc/do_damage(var/turf/T, var/living_damage = 1, var/mineral_damage = 1)
 	var/datum/gas_mixture/environment = T.return_air()
-	living_damage *= max(1 - (environment.return_pressure() / 100) * 0.75, 0)
+	living_damage *= max(1 - (environment.return_pressure() / 50) * 0.75, 0)
 	new /obj/effect/overlay/temp/kinetic_blast(T)
 	for(var/mob/living/L in T)
 		L.take_overall_damage(min(living_damage, 50))


### PR DESCRIPTION
KA Damage to living mobs is specific to environmental pressure, nerfed the penalty by 50% to account for our atmosphere. Should make them viable against carps and such without giving miners WMDs.

Allows the following suits to throw a backpack into their suit storrage:
-Engineer EVA Rig
-Mining RIG
-Merc Rig
-CE Rig
-Offworlder Exosuit Rig